### PR TITLE
Implement rate limiting for HTTP requests to avoid hitting Trello limits

### DIFF
--- a/T2MDCli/Cli.cs
+++ b/T2MDCli/Cli.cs
@@ -9,14 +9,16 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using GoldenSyrupGames.T2MD.Http;
 
 namespace GoldenSyrupGames.T2MD
 {
+
     public class Cli
     {
-        // create the HttpClient we'll use for all our requests. see
-        // https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
-        private static HttpClient _httpClient = new HttpClient();
+        // create the rate-limited HttpClient we'll use for all our requests
+        // see https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
+        private static RateLimitedHttpClient _httpClient = new RateLimitedHttpClient(HttpConstants.DefaultRateLimit);
 
         // Trello credentials
         private static string _apiKey = "";
@@ -58,6 +60,14 @@ namespace GoldenSyrupGames.T2MD
         {
             AnsiConsole.MarkupLine($"[cyan]Output path: {options.OutputPath}[/]");
             AnsiConsole.MarkupLine($"[cyan]Config file: {options.ConfigFilePath}[/]");
+
+            // Reinitialize the rate-limited HTTP client with the configured rate limit, if not default
+            if (options.RateLimit != HttpConstants.DefaultRateLimit)
+            {
+                _httpClient.Dispose();
+                _httpClient = new RateLimitedHttpClient(options.RateLimit);
+            }
+            AnsiConsole.MarkupLine($"[cyan]Rate limit: {options.RateLimit} requests per second[/]");
 
             // ensure our output folder exists.
             // use a subfolder of the user-specified path for safety

--- a/T2MDCli/Cli.cs
+++ b/T2MDCli/Cli.cs
@@ -44,8 +44,8 @@ namespace GoldenSyrupGames.T2MD
         static async Task Main(string[] args)
         {
             // get commandline arguments based on CliOptions, otherwise fail and print help.
-            await Parser
-                .Default.ParseArguments<CliOptions>(args)
+            await Parser.Default
+                .ParseArguments<CliOptions>(args)
                 .MapResult(
                     // when we have all valid options
                     RunAsync,
@@ -216,8 +216,8 @@ namespace GoldenSyrupGames.T2MD
             AnsiConsole.MarkupLine("[magenta]Processing each board (phase 1):[/]");
             var boardTasks = new List<Task<TrelloBoardModel>>();
             foreach (
-                TrelloApiBoardModel trelloApiBoard in trelloApiBoards.Where(b =>
-                    ShouldBackupBoard(b.Name)
+                TrelloApiBoardModel trelloApiBoard in trelloApiBoards.Where(
+                    b => ShouldBackupBoard(b.Name)
                 )
             )
             {
@@ -346,8 +346,8 @@ namespace GoldenSyrupGames.T2MD
 
             string boardOutputFilePath = Path.Combine(_outputPath, $"{usableBoardName}.json");
             using FileStream fileStream = File.Create(boardOutputFilePath);
-            using Stream contentStream = await response
-                .Content.ReadAsStreamAsync()
+            using Stream contentStream = await response.Content
+                .ReadAsStreamAsync()
                 .ConfigureAwait(false);
             await contentStream.CopyToAsync(fileStream).ConfigureAwait(false);
 
@@ -377,8 +377,8 @@ namespace GoldenSyrupGames.T2MD
             }
 
             // sort the lists by their position in the board so we order the same way as the GUI
-            IOrderedEnumerable<TrelloListModel> orderedLists = trelloBoard.Lists.OrderBy(list =>
-                list.Pos
+            IOrderedEnumerable<TrelloListModel> orderedLists = trelloBoard.Lists.OrderBy(
+                list => list.Pos
             );
 
             // differentiate duplicate list names
@@ -410,8 +410,8 @@ namespace GoldenSyrupGames.T2MD
             // - fun fact: Trello doesn't use contiguous ints for their position: they use
             //   large-ranging floats so that card positions can be updated without recalculating
             //   all.
-            IOrderedEnumerable<TrelloCardModel> orderedCards = trelloBoard.Cards.OrderBy(card =>
-                card.Pos
+            IOrderedEnumerable<TrelloCardModel> orderedCards = trelloBoard.Cards.OrderBy(
+                card => card.Pos
             );
 
             // differentiate duplicate cards. Do it per list because lists will become folders,
@@ -425,8 +425,8 @@ namespace GoldenSyrupGames.T2MD
             var CardTasks = new List<Task>();
             foreach (TrelloCardModel trelloCard in orderedCards)
             {
-                TrelloListModel parentList = trelloBoard
-                    .Lists.Where(list => list.ID == trelloCard.IDList)
+                TrelloListModel parentList = trelloBoard.Lists
+                    .Where(list => list.ID == trelloCard.IDList)
                     .First();
 
                 // give the card the right index and path depending on whether it's archived or not.
@@ -1221,8 +1221,8 @@ namespace GoldenSyrupGames.T2MD
                 );
                 // write the attachment to disk
                 using FileStream attachmentFileStream = File.Create(attachmentPath);
-                using Stream attachmentContentStream = await attachmentResponse
-                    .Content.ReadAsStreamAsync()
+                using Stream attachmentContentStream = await attachmentResponse.Content
+                    .ReadAsStreamAsync()
                     .ConfigureAwait(false);
                 await attachmentContentStream
                     .CopyToAsync(attachmentFileStream)

--- a/T2MDCli/Cli.cs
+++ b/T2MDCli/Cli.cs
@@ -1,24 +1,25 @@
-﻿using System;
-using CommandLine;
-using Spectre.Console;
-using System.Text.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
 using System.Linq;
-using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using CommandLine;
 using GoldenSyrupGames.T2MD.Http;
+using Spectre.Console;
 
 namespace GoldenSyrupGames.T2MD
 {
-
     public class Cli
     {
         // create the rate-limited HttpClient we'll use for all our requests
         // see https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
-        private static RateLimitedHttpClient _httpClient = new RateLimitedHttpClient(HttpConstants.DefaultRateLimit);
+        private static RateLimitedHttpClient _httpClient = new RateLimitedHttpClient(
+            HttpConstants.DefaultRateLimit
+        );
 
         // Trello credentials
         private static string _apiKey = "";
@@ -37,14 +38,14 @@ namespace GoldenSyrupGames.T2MD
             // with pos values as strings, e.g. "123.45". Support those
             NumberHandling = JsonNumberHandling.AllowReadingFromString,
             // Trello also (used to?) encode some positions as "bottom". Handle that
-            Converters = { new TrelloDoubleJsonConverter() }
+            Converters = { new TrelloDoubleJsonConverter() },
         };
 
         static async Task Main(string[] args)
         {
             // get commandline arguments based on CliOptions, otherwise fail and print help.
-            await Parser.Default
-                .ParseArguments<CliOptions>(args)
+            await Parser
+                .Default.ParseArguments<CliOptions>(args)
                 .MapResult(
                     // when we have all valid options
                     RunAsync,
@@ -184,7 +185,8 @@ namespace GoldenSyrupGames.T2MD
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
 
-            bool ShouldBackupBoard(string boardName) => includeAllBoards || includedBoardsLookup.ContainsKey(boardName);
+            bool ShouldBackupBoard(string boardName) =>
+                includeAllBoards || includedBoardsLookup.ContainsKey(boardName);
 
             // list them
             AnsiConsole.MarkupLine("[magenta]Boards to back up:[/]");
@@ -209,13 +211,15 @@ namespace GoldenSyrupGames.T2MD
                 options
             );
 
-            
-
             // process each board asynchronously. The downloading, writing, as much of the process
             // as possible.
             AnsiConsole.MarkupLine("[magenta]Processing each board (phase 1):[/]");
             var boardTasks = new List<Task<TrelloBoardModel>>();
-            foreach (TrelloApiBoardModel trelloApiBoard in trelloApiBoards.Where(b => ShouldBackupBoard(b.Name)))
+            foreach (
+                TrelloApiBoardModel trelloApiBoard in trelloApiBoards.Where(b =>
+                    ShouldBackupBoard(b.Name)
+                )
+            )
             {
                 // Starting each board with Task.Run is consistently faster than just async/await
                 // within the board, even though it's I/O bound. Probably because the JSON parsing
@@ -342,8 +346,8 @@ namespace GoldenSyrupGames.T2MD
 
             string boardOutputFilePath = Path.Combine(_outputPath, $"{usableBoardName}.json");
             using FileStream fileStream = File.Create(boardOutputFilePath);
-            using Stream contentStream = await response.Content
-                .ReadAsStreamAsync()
+            using Stream contentStream = await response
+                .Content.ReadAsStreamAsync()
                 .ConfigureAwait(false);
             await contentStream.CopyToAsync(fileStream).ConfigureAwait(false);
 
@@ -373,8 +377,8 @@ namespace GoldenSyrupGames.T2MD
             }
 
             // sort the lists by their position in the board so we order the same way as the GUI
-            IOrderedEnumerable<TrelloListModel> orderedLists = trelloBoard.Lists.OrderBy(
-                list => list.Pos
+            IOrderedEnumerable<TrelloListModel> orderedLists = trelloBoard.Lists.OrderBy(list =>
+                list.Pos
             );
 
             // differentiate duplicate list names
@@ -406,8 +410,8 @@ namespace GoldenSyrupGames.T2MD
             // - fun fact: Trello doesn't use contiguous ints for their position: they use
             //   large-ranging floats so that card positions can be updated without recalculating
             //   all.
-            IOrderedEnumerable<TrelloCardModel> orderedCards = trelloBoard.Cards.OrderBy(
-                card => card.Pos
+            IOrderedEnumerable<TrelloCardModel> orderedCards = trelloBoard.Cards.OrderBy(card =>
+                card.Pos
             );
 
             // differentiate duplicate cards. Do it per list because lists will become folders,
@@ -421,8 +425,8 @@ namespace GoldenSyrupGames.T2MD
             var CardTasks = new List<Task>();
             foreach (TrelloCardModel trelloCard in orderedCards)
             {
-                TrelloListModel parentList = trelloBoard.Lists
-                    .Where(list => list.ID == trelloCard.IDList)
+                TrelloListModel parentList = trelloBoard
+                    .Lists.Where(list => list.ID == trelloCard.IDList)
                     .First();
 
                 // give the card the right index and path depending on whether it's archived or not.
@@ -1217,8 +1221,8 @@ namespace GoldenSyrupGames.T2MD
                 );
                 // write the attachment to disk
                 using FileStream attachmentFileStream = File.Create(attachmentPath);
-                using Stream attachmentContentStream = await attachmentResponse.Content
-                    .ReadAsStreamAsync()
+                using Stream attachmentContentStream = await attachmentResponse
+                    .Content.ReadAsStreamAsync()
                     .ConfigureAwait(false);
                 await attachmentContentStream
                     .CopyToAsync(attachmentFileStream)
@@ -1503,7 +1507,7 @@ namespace GoldenSyrupGames.T2MD
             {
                 trelloCard.DescriptionPath,
                 trelloCard.CommentsPath,
-                trelloCard.ChecklistsPath
+                trelloCard.ChecklistsPath,
             }.Distinct();
 
             var fileTasks = new List<Task>();

--- a/T2MDCli/CliOptions.cs
+++ b/T2MDCli/CliOptions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Code and classes for commandline options the program uses.
  */
 
@@ -47,9 +47,9 @@ namespace GoldenSyrupGames.T2MD
             "boards-to-include",
             Required = false,
             HelpText = "If specified, limits which boards are backed up.\n"
-                       + "Board names can be selected from the 'list-boards-only' operation.\n"
-                       + "Board names can be separated by spaces and should contain quotes if the name has spaces: "
-                       + "--boards-to-include \"board 1\" \"board 2\""
+                + "Board names can be selected from the 'list-boards-only' operation.\n"
+                + "Board names can be separated by spaces and should contain quotes if the name has spaces: "
+                + "--boards-to-include \"board 1\" \"board 2\""
         )]
         public IEnumerable<string> BoardsToInclude { get; set; } = new List<string>();
 
@@ -163,9 +163,9 @@ namespace GoldenSyrupGames.T2MD
         [Option(
             "rate-limit",
             Default = HttpConstants.DefaultRateLimit,
-            HelpText = "The maximum number of API requests per second to make to Trello.\n" +
-                "Set to a higher value (maybe up to 30 or so) to improve performance; the " +
-                "default is fairly conservative."
+            HelpText = "The maximum number of API requests per second to make to Trello.\n"
+                + "Set to a higher value (maybe up to 30 or so) to improve performance; the "
+                + "default is fairly conservative."
         )]
         public int RateLimit { get; set; } = HttpConstants.DefaultRateLimit;
 

--- a/T2MDCli/CliOptions.cs
+++ b/T2MDCli/CliOptions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CommandLine;
+using GoldenSyrupGames.T2MD.Http;
 
 namespace GoldenSyrupGames.T2MD
 {
@@ -155,6 +156,18 @@ namespace GoldenSyrupGames.T2MD
                 + "table."
         )]
         public int ObsidianAttachmentPreviewWidth { get; set; } = 0;
+
+        /// <summary>
+        /// The maximum number of API requests per second to make to Trello.
+        /// </summary>
+        [Option(
+            "rate-limit",
+            Default = HttpConstants.DefaultRateLimit,
+            HelpText = "The maximum number of API requests per second to make to Trello.\n" +
+                "Set to a higher value (maybe up to 30 or so) to improve performance; the " +
+                "default is fairly conservative."
+        )]
+        public int RateLimit { get; set; } = HttpConstants.DefaultRateLimit;
 
         public static Task PrintUsage(IEnumerable<Error> errors)
         {

--- a/T2MDCli/HttpUtilities.cs
+++ b/T2MDCli/HttpUtilities.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace GoldenSyrupGames.T2MD.Http
+{
+    /// <summary>
+    /// Constants for HTTP utilities
+    /// </summary>
+    public static class HttpConstants
+    {
+        /// <summary>
+        /// Default rate limit in requests per second
+        /// </summary>
+        public const int DefaultRateLimit = 10;
+    }
+
+    // Rate limiting class for controlling API request rates
+    public sealed class RateLimiter : IDisposable
+    {
+        private readonly SemaphoreSlim _semaphore;
+        private readonly int _requestsPerSecond;
+        private readonly Channel<DateTime> _requestTimestamps;
+        private readonly CancellationTokenSource _cts;
+
+        public RateLimiter(int requestsPerSecond)
+        {
+            _requestsPerSecond = Math.Max(1, requestsPerSecond); // Ensure minimum of 1 request per second
+            _semaphore = new SemaphoreSlim(_requestsPerSecond, _requestsPerSecond);
+            _requestTimestamps = Channel.CreateUnbounded<DateTime>();
+            _cts = new CancellationTokenSource();
+            // Start the cleanup task without keeping a reference
+            // This task will run for the lifetime of the RateLimiter instance
+            _ = RunCleanupAsync(_cts.Token);
+        }
+
+        private async Task RunCleanupAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    // Wait for the next timestamp
+                    if (await _requestTimestamps.Reader.WaitToReadAsync(cancellationToken))
+                    {
+                        if (_requestTimestamps.Reader.TryPeek(out DateTime oldestRequest))
+                        {
+                            // Calculate time to wait until the oldest request can be released (1 second from its timestamp)
+                            TimeSpan timeToWait = oldestRequest.AddSeconds(1) - DateTime.UtcNow;
+
+                            if (timeToWait > TimeSpan.Zero)
+                            {
+                                await Task.Delay(timeToWait, cancellationToken);
+                            }
+
+                            // Remove the timestamp and release the semaphore
+                            if (_requestTimestamps.Reader.TryRead(out _))
+                            {
+                                _semaphore.Release();
+                            }
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when cancellation is requested
+            }
+        }
+
+        public async Task WaitAsync()
+        {
+            await _semaphore.WaitAsync();
+            await _requestTimestamps.Writer.WriteAsync(DateTime.UtcNow);
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _semaphore.Dispose();
+            _cts.Dispose();
+        }
+    }
+
+    // HTTP client wrapper that enforces rate limiting for all requests
+    public sealed class RateLimitedHttpClient : IDisposable
+    {
+        private readonly HttpClient _httpClient;
+        private readonly RateLimiter _rateLimiter;
+
+        public RateLimitedHttpClient(int requestsPerSecond)
+        {
+            _httpClient = new HttpClient();
+            _rateLimiter = new RateLimiter(requestsPerSecond);
+        }
+
+        public async Task<string> GetStringAsync(string url)
+        {
+            await _rateLimiter.WaitAsync();
+            return await _httpClient.GetStringAsync(url);
+        }
+
+        public async Task<HttpResponseMessage> GetAsync(string url)
+        {
+            await _rateLimiter.WaitAsync();
+            return await _httpClient.GetAsync(url);
+        }
+
+        public async Task<HttpResponseMessage> PostAsync(string url, HttpContent content)
+        {
+            await _rateLimiter.WaitAsync();
+            return await _httpClient.PostAsync(url, content);
+        }
+
+        public async Task<byte[]> GetByteArrayAsync(string url)
+        {
+            await _rateLimiter.WaitAsync();
+            return await _httpClient.GetByteArrayAsync(url);
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            await _rateLimiter.WaitAsync();
+            return await _httpClient.SendAsync(request);
+        }
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+            _rateLimiter.Dispose();
+        }
+    }
+}

--- a/T2MDCli/T2MDCli.csproj
+++ b/T2MDCli/T2MDCli.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>t2md</AssemblyName>
     <Authors>Ben Renninson</Authors>
     <Company>Golden Syrup Games</Company>
-    <Version>4.1.1</Version>
+    <Version>4.2.0</Version>
     <Copyright>2022 Golden Syrup Games</Copyright>
     <PackageLicenseExpression></PackageLicenseExpression>
 


### PR DESCRIPTION
Wrap the HttpClient in a RateLimitedHttpClient, that limits the number of requests per second.

Allows 10 requests per second as a conservative default, but can be configured via the `--rate-limit` option.

The implementation relies on a RateLimiter instance that uses a semaphore to allow only the given number of requests until slots are released again. New HTTP requests will consume a semaphore slot, and push the current time as a DateTime onto a channel.

The RateLimiter runs a cleanup task in the background, that continually peeks at the oldest timestamp in the channel. If a second has passed since the given timestamp, the timestamp is consumed from the channel and a semaphore slot is released.

Fixes #45.